### PR TITLE
add `warning_cutoff` to `load` check

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remotesysmonitor"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "A tool for monitoring remote servers."
 repository = "https://github.com/rvhonorato/remotesysmonitor"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ ssh2 = "0"
 reqwest = { version = "0.12.4", features = ["blocking"] }
 tokio = { version = "1", features = ["full"] }
 regex = "1"
-slack-hook = "0"
+slack-hook = "0.8"
 chrono = "0"
 clap = { version = "4", features = ["derive"] }
 log = "0"

--- a/src/config.rs
+++ b/src/config.rs
@@ -61,6 +61,8 @@ pub enum Check {
     Load {
         /// Time interval in seconds over which to calculate the load average.
         interval: u16,
+        /// Cutoff to signal de load as a warning
+        warning_cutoff: f64,
     },
     /// Count the number of subfolders in a specified path.
     NumberOfSubfolders {

--- a/src/main.rs
+++ b/src/main.rs
@@ -162,9 +162,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         checks::ping(&("https://".to_owned() + server.host.as_str()), url)
                     }
                     Check::Temperature { sensor } => checks::temperature(&sess, sensor.as_str()),
-                    Check::Load { interval } => {
-                        checks::load(&sess, server.name.as_str(), *interval)
-                    }
+                    Check::Load {
+                        interval,
+                        warning_cutoff,
+                    } => checks::load(&sess, server.name.as_str(), *interval, *warning_cutoff),
                     Check::NumberOfSubfolders { path, max_folders } => {
                         checks::number_of_folders(&sess, server.name.as_str(), path, max_folders)
                     }


### PR DESCRIPTION
This PR adds a new parameter to the `load` check to be able to customize the warning - previously this was hardcoded to 50.0